### PR TITLE
TD-50 TD-51 License, README, and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,6 +132,7 @@ dmypy.json
 app.db
 *.db
 
+.idea
 .vscode
 dev.html
 dev.py

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2022 The Droids Stock Trader
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Make sure that you have at least python 3.8 installed. Steps 1, 2, 4, and 5 only
 1. Clone the repository
 
     ```
-    $ git clone git@github.com:tmsoc/Stock_Trader.git
+    $ git clone https://github.com/Droids-Stock-Trader/Stock_Trader.git
     $ cd Stock_Trader
     ```
 


### PR DESCRIPTION
This pull request covers TD-50 and TD-51.

The following changes were made:
1. The link to this repository in the README setup instructions was corrected to link to the organization repository.
2. The MIT license was added to the project.
3. .idea was added to the .gitignore file to prevent tracking of JetBrains' IDE files.