### PR TITLE
TD-77 username change notification email

### DIFF
--- a/app/emails/email.py
+++ b/app/emails/email.py
@@ -14,3 +14,10 @@ def send_password_reset_email(user):
                sender='jerry.aragon@student.csulb.edu', recipients=[user.email],
                text_body=render_template('email/reset_password.txt', user=user, token=token),
                html_body=render_template('email/reset_password.html',user=user, token=token))
+
+def send_notification_email(changes_made, user):
+    for attribute in changes_made:
+        send_email('Stock Trader: ' + attribute + ' Change Notification',
+                   sender='jerry.aragon@student.csulb.edu', recipients=[user.email],
+                   text_body=render_template('email/notification_change.txt', user=user),
+                   html_body=render_template('email/notification_change.html',user=user))

--- a/app/settings/routes.py
+++ b/app/settings/routes.py
@@ -33,8 +33,8 @@ def user_preferences():
             current_user.store_history_record(record)
             db.session.commit()
             # sends a notification email based on the attributes changed
-            # if the contact preference is set to email
-            if (current_user.contact_pref == 1):
+            # if the contact preference is set to email and notifications are turned on
+            if (current_user.contact_pref == 1 and current_user.account_change_notify):
                 send_notification_email(changes_made, current_user)
             flash("User profile have been saved")
     # populates the profile page with the current users attributes

--- a/app/settings/routes.py
+++ b/app/settings/routes.py
@@ -5,6 +5,7 @@ from app import db
 from app.settings import bp
 from app.settings.forms import ProfileForm, NotificationForm, HeadlinesForm
 from app.models import History, News_Settings
+from app.emails.email import send_notification_email
 
 
 @bp.route('/profile', methods=['GET', 'POST'])
@@ -31,6 +32,8 @@ def user_preferences():
             )
             current_user.store_history_record(record)
             db.session.commit()
+            # sends a notification email based on the attributes changed
+            send_notification_email(changes_made, current_user)
             flash("User profile have been saved")
     # populates the profile page with the current users attributes
     _populate_profile_form(form)

--- a/app/settings/routes.py
+++ b/app/settings/routes.py
@@ -33,7 +33,9 @@ def user_preferences():
             current_user.store_history_record(record)
             db.session.commit()
             # sends a notification email based on the attributes changed
-            send_notification_email(changes_made, current_user)
+            # if the contact preference is set to email
+            if (current_user.contact_pref == 1):
+                send_notification_email(changes_made, current_user)
             flash("User profile have been saved")
     # populates the profile page with the current users attributes
     _populate_profile_form(form)

--- a/app/templates/email/notification_change.html
+++ b/app/templates/email/notification_change.html
@@ -1,0 +1,6 @@
+<p>Dear {{ user.username }},</p>
+<p>This is an email notification of a change to your account.</p>
+<p>If you made this change, please ignore this email.</p>
+<p>If you believe someone has unauthorized access to your account, please contact us immediately.</p>
+<p>Sincerely,</p>
+<p>The Droids Support Services</p>

--- a/app/templates/email/notification_change.txt
+++ b/app/templates/email/notification_change.txt
@@ -1,0 +1,10 @@
+Dear {{ user.username }},
+
+This is an email notification of a change to your account.
+
+If you made this change, please ignore this email.
+If you believe someone has unauthorized access to your account, please contact us immediately.
+
+Sincerely,
+
+The Droids Support Services


### PR DESCRIPTION
You will now receive an email notification for the following changes: email, phone number, DOB, username, and contact preference. An email notification for a password change will be implemented in another pull request, as the process will be different since you don't change the password the same way you change your other attributes. I will also improve the email change notifications in the next pull request as well.